### PR TITLE
Pt 6582723 bctt script

### DIFF
--- a/test/bctt
+++ b/test/bctt
@@ -81,13 +81,10 @@ do_test(State0) ->
     io:format("\nInitial populate.\n"),
     State1 = start_writer(State0),
     kick_writer(State1),
-    receive
-        {'EXIT', _From, Why} ->
-            erlang:error({writer_failed, Why});
+    wait_for_writer(State1),
 
-        {write_done, 1} ->
-            ok
-    end,
+    %% Start continually rewriting the keys and optionally reading,
+    %% folding and merging
     State = State1#state{seq = 1},
     kick_writer(State),
     start_readers(State, State#state.readers),
@@ -147,6 +144,19 @@ restart_procs(State) ->
         Other ->
             io:format("Restart procs got unexpected message\n~p\n", [Other]),
             State
+    end.
+
+%% Wait for the initial writer to complete - the os:cmd call
+%% can generate an EXIT message
+wait_for_writer(State) ->
+    WriterPid = State#state.writer_pid,
+    receive
+        {'EXIT', WriterPid, Why} ->
+            erlang:error({initial_write_failed, Why});
+        {'EXIT', _Pid, _Why} ->
+            wait_for_writer(State);
+        {write_done, 1} ->
+            ok
     end.
 
 wait_for_procs(#state{writers = 0, readers = 0, folders = 0, mergers = 0}) ->


### PR DESCRIPTION
Script to do unkindt things to bitcask.

To trigger the error if the writer is being restarted (bz://888)

  test/bctt --duration=60000 max_file_size=10485760 restart_writer=true num_keys=1 readers=1

To exercise the fold missing keys when adding files to the cask (bz://889)

   test/bctt --duration=60000 max_file_size=100000 folders=1
