### PR TITLE
Performance avoid filename join - in bitcask:get_filestate()

### DIFF
--- a/src/bitcask.erl
+++ b/src/bitcask.erl
@@ -721,7 +721,7 @@ get_filestate(FileId,
         {value, Filestate} ->
             {Filestate, State};
         false ->
-	    Fname = bitcask_fileops:mk_filename(Dirname, FileId),
+            Fname = bitcask_fileops:mk_filename(Dirname, FileId),
             case bitcask_fileops:open_file(Fname) of
                 {error,enoent} ->
                     %% merge removed the file since the keydir_get


### PR DESCRIPTION
bitcask:get_filestate(): Only call filename:join() when needed.
Profiling showed that filename:join() consumed quite a bit of time (eprof said 6% in a Riak use case).
By using the FileId as key instead of the filename, we can avoid this overhead.
