### PR TITLE
Added 'ebin' to the list of ignored files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .eunit/*
 deps/*
+ebin
 priv/*
 *.o
 *.beam


### PR DESCRIPTION
The 'ebin' directory auto-generated by Rebar, so it needs to be ignored.
