### PR TITLE
Don't use include_lib for local include files.

### DIFF
--- a/test/bitcask_qc.erl
+++ b/test/bitcask_qc.erl
@@ -27,7 +27,7 @@
 
 -include_lib("eqc/include/eqc.hrl").
 -include_lib("eunit/include/eunit.hrl").
--include_lib("bitcask/include/bitcask.hrl").
+-include("bitcask.hrl").
 
 -compile(export_all).
 

--- a/test/bitcask_qc_expiry.erl
+++ b/test/bitcask_qc_expiry.erl
@@ -25,7 +25,7 @@
 
 -include_lib("eqc/include/eqc.hrl").
 -include_lib("eunit/include/eunit.hrl").
--include_lib("bitcask/include/bitcask.hrl").
+-include("bitcask.hrl").
 
 -compile(export_all).
 


### PR DESCRIPTION
This breaks the EQC tests when the toplevel dir is not called 'bitcask'.
