### PR TITLE
Tighten bitcask data file regex (currently picks up NNNN.bitcask.data*)

### DIFF
--- a/src/bitcask_fileops.erl
+++ b/src/bitcask_fileops.erl
@@ -114,7 +114,7 @@ close_for_writing(State =
 %% match our regex. 
 -spec data_file_tstamps(Dirname :: string()) -> [{integer(), string()}].
 data_file_tstamps(Dirname) ->
-    filelib:fold_files(Dirname, "[0-9]+.bitcask.data$", false,
+    filelib:fold_files(Dirname, "^[0-9]+.bitcask.data$", false,
                        fun(F, Acc) ->
                                [{file_tstamp(F), F} | Acc]
                        end, []).


### PR DESCRIPTION
Make sure the regex used to find data files is tight so that if people move bitcask files out of the way during recovery e.g. 123.bitcask.data.bak then they are not included when deciding on the next filename.
