### PR TITLE
remove arbitrary 120-char limit on log_needs_merge messages

### DIFF
--- a/src/bitcask.erl
+++ b/src/bitcask.erl
@@ -587,7 +587,7 @@ needs_merge(Ref) ->
             %%       recv this information and decide if they want it
             case get_opt(log_needs_merge, State#bc_state.opts) of
                 true ->
-                    error_logger:info_msg("~p needs_merge: ~120p\n",
+                    error_logger:info_msg("~p needs_merge: ~p\n",
                                           [State#bc_state.dirname, MergableFiles]);
                 _ ->
                     ok


### PR DESCRIPTION
lager already chops log messages to 4kb

Sample entry for a single file exceeds 120 chars:
[{"./data/bitcask/bitcask/411047335499316445744786359201454599278231027712/1315.bitcask.data",[{oldest_tstamp,1342805897,1343043808}]}]
