### PR TITLE
Fix file descriptor leak after start() after AC power failure

### DIFF
--- a/src/bitcask.erl
+++ b/src/bitcask.erl
@@ -23,7 +23,6 @@
 -author('Dave Smith <dizzyd@basho.com>').
 -author('Justin Sheehy <justin@basho.com>').
 
--export([t0/0, t1/0]). %%% SLF debugging DELETEME
 -export([open/1, open/2,
          close/1,
          close_write_file/1,
@@ -1668,15 +1667,15 @@ truncate_file(Path, Offset) ->
     ok = file:truncate(FH),
     file:close(FH).    
 
--endif.
-
+%% About leak_t0():
+%%
 %% If bitcask leaks file descriptors for the 'touch'ed files, output is:
 %%    Res =      920
 %%
 %% If bitcask isn't leaking the 'touch'ed files, output is:
 %%    Res =       20
 
-t0() ->
+leak_t0() ->
     Dir = "/tmp/goofus",
     os:cmd("rm -rf " ++ Dir),
 
@@ -1687,7 +1686,7 @@ t0() ->
     Cmd = lists:flatten(io_lib:format("lsof -nP -p ~p | wc -l", [os:getpid()])),
     io:format("Res = ~s\n", [os:cmd(Cmd)]).
 
-t1() ->
+leak_t1() ->
     Dir = "/tmp/goofus",
     NumKeys = 300,
     os:cmd("rm -rf " ++ Dir),
@@ -1717,3 +1716,5 @@ t1() ->
     io:format("Now, lsof says: ~s", [Used()]),
 
     ok.
+
+-endif.


### PR DESCRIPTION
A customer reports an eleveldb problem (`emfile` errors due to file
descriptor leaking) that was apparently the result of the twisted
flaming wreckage of:
1. A large ring size on a small cluster of machines (exact ring
   size unknown, cluster size likely 5 or 7 nodes)
2. Under an extremely heavy Riak CS workload, which was under a
   high stress workload involving exclusively files at 10+ MByte and
   thus writing much more data to Bitcask than a high stress workload
   involving 10 byte files.
3. The power plug was pulled/tripped/popped on one of the Riak
   nodes.
4. The machine promptly rebooted, checked file system state, and
   attempted to restart Riak.
5. Riak restarted with most/all? Bitcask instances complaining about
   truncated data & hint files but appeared to start them successfully.
6. However, file descriptor leaks caused eleveldb instances to crash
   with `emfile` errors.

This fix introduces a new parameter to `scan_key_files()`, telling
it to close files (or not) as it folds across each data file.

The two test functions, `t0/0` and `t1/0`, are added to show the
effect of the file descriptor leakage.  The former shows how
the leak at `bitcask:start()` is addressed by this patch.  Leaks
via merge or delete as shown by `t1/0` are not addressed.  Both
functions are not really demos and not yet eunit tests (due to
relying on platform-specific utilities like `seq` and `lsof`).
