### PR TITLE
Add bitcask:is_empty_estimate

### DIFF
--- a/src/bitcask.erl
+++ b/src/bitcask.erl
@@ -35,6 +35,7 @@
          fold/3, fold/5,
          merge/1, merge/2, merge/3,
          needs_merge/1,
+         is_empty_estimate/1,
          status/1]).
 
 -export([get_opt/2,
@@ -647,6 +648,11 @@ expired_threshold(Cutoff) ->
             end
     end.
 
+-spec is_empty_estimate(reference()) -> boolean().
+is_empty_estimate(Ref) ->
+    State = get_state(Ref),
+    {KeyCount, _, _} = bitcask_nifs:keydir_info(State#bc_state.keydir),
+    KeyCount == 0.
 
 -spec status(reference()) -> {integer(), [{string(), integer(), integer(), integer()}]}.
 status(Ref) ->


### PR DESCRIPTION
Add bitcask:is_empty_estimate to quickly determine if a bitcask contains no data. Currently, determining if a bitcask has data requires folding over the keydir to ensure tombstones and expired keys are skipped. However, this is a potentially blocking operation and no where in Riak do we actually need perfect knowledge.

The estimate is determined from the bitcask stats, which may overcount data, but will not undercount. Therefore, the estimated result may return false when the bitcask is actually empty, but it will never return true when there is data.

See issue: basho/riak_kv#423
