### PR TITLE
Change default Bitcask I/O mode to Erlang

### DIFF
--- a/src/bitcask_io.erl
+++ b/src/bitcask_io.erl
@@ -71,5 +71,5 @@ determine_file_module() ->
         {ok, nif} ->
             bitcask_nifs;
         _ ->
-            bitcask_nifs
+            bitcask_file
     end.


### PR DESCRIPTION
Additional testing demonstrates that using Erlang's built-in I/O provides more consistent behavior than the synchronous NIF approach. While the NIF approach is known to provide higher throughput, the non-deterministic impact on the Erlang VM from the use of blocking NIFs outweighs the benefit. Defaulting to the safer option. Users can manually revert to using NIFs if desired.
