### PR TITLE
Improve fold speed for large files filled with small objects.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ ebin
 priv/*.so
 *.o
 *.beam
+*~
+#*#

--- a/include/bitcask.hrl
+++ b/include/bitcask.hrl
@@ -37,3 +37,8 @@
 -define(MAXKEYSIZE, 2#1111111111111111).
 -define(MAXVALSIZE, 2#11111111111111111111111111111111).
 -define(MAXOFFSET, 16#ffffffffffffffff). % max 64-bit unsigned
+
+%% for hintfile validation
+-define(CHUNK_SIZE, 65535).
+-define(MIN_CHUNK_SIZE, 1024).
+-define(MAX_CHUNK_SIZE, 134217728).

--- a/src/bitcask_io.erl
+++ b/src/bitcask_io.erl
@@ -54,6 +54,10 @@ file_seekbof(Ref) ->
     M = file_module(),
     M:file_seekbof(Ref).
 
+file_position(Ref, Position) ->
+    M = file_module(),
+    M:file_position(Ref, Position).
+
 file_module() ->
     case get(bitcask_file_mod) of
         undefined ->

--- a/src/bitcask_nifs.erl
+++ b/src/bitcask_nifs.erl
@@ -49,6 +49,7 @@
          file_pwrite/3,
          file_read/2,
          file_write/2,
+         file_position/2,
          file_seekbof/1]).
 
 -on_load(init/0).
@@ -380,6 +381,13 @@ file_write(Ref, Bytes) ->
     file_write_int(Ref, Bytes).
 
 file_write_int(_Ref, _Bytes) ->
+    erlang:nif_error({error, not_loaded}).
+
+file_position(Ref, Position) ->
+    bitcask_bump:big(),
+    file_position_int(Ref, Position).
+
+file_position_int(_Ref, _Position) ->
     erlang:nif_error({error, not_loaded}).
 
 file_seekbof(Ref) ->

--- a/test/bcfold_perf
+++ b/test/bcfold_perf
@@ -1,0 +1,104 @@
+#!/usr/bin/env escript
+
+-mode(compile).
+
+main(Args) when length(Args) >= 2 ->
+    [DataDir | List] = Args,
+    [begin
+         test_small(DataDir, D),
+         test_medium(DataDir,D),
+         test_large(DataDir,D),
+         test_cs(DataDir,D) 
+     end || 
+        D <- List];
+main(_) ->
+    usage().
+
+usage() ->
+    io:format("bcfold_perf <data_dir> <branch dir>+~n"),
+    io:format("run bcfold_setup <data_dir> before running this~n").
+        
+test(DataDir, BranchDir, Subdir) ->
+    Modlist = ensure_and_load_bitcask(BranchDir),
+    time_folds(DataDir, Subdir),
+    cleanup(Modlist).
+
+test_small(DataDir, BranchDir) ->
+    test(DataDir, BranchDir, "small").
+
+test_medium(DataDir, BranchDir) ->
+    test(DataDir, BranchDir, "medium").
+
+test_large(DataDir, BranchDir) ->
+    test(DataDir, BranchDir, "large").
+
+test_cs(DataDir, BranchDir) ->
+    test(DataDir, BranchDir, "cs").
+
+sum(_, _, A0) -> 
+    A0 + 1.
+
+sum(_, _, _, A0) -> 
+    A0 + 1.
+
+
+time_folds(DataDir, SubDir) ->
+    clean_env(),
+    %% this is basically a proxy for hintfile folds and 
+    %% the CRC check
+    {OpenTime, Ref} = timer:tc(bitcask, open, 
+                               [DataDir++SubDir++"/"]),
+    %%bitcask:close(Ref),
+    
+    clean_env(),
+    {ok, Fd1} = 
+        bitcask_fileops:open_file(DataDir++SubDir++"/1.bitcask.data"),
+    {FoldDatafileKeyTime, Count} =
+        timer:tc(bitcask_fileops, fold_keys,
+                 [Fd1, fun sum/4, 0, datafile]),
+    bitcask_io:file_close(Fd1),
+    
+    clean_env(),
+    {FoldDatafileTime, Count2} =
+        timer:tc(bitcask, fold, [Ref, fun sum/3, 0]),
+    
+    
+    io:format("Report for run: ~s~n", [SubDir]),
+    io:format("Open:              ~15w~n", [OpenTime]),
+    io:format("Datafile Key Fold: ~15w~10w~n", [FoldDatafileKeyTime, Count]),
+    io:format("Datafile Fold:     ~15w~10w~n~n", [FoldDatafileTime, Count2]).
+
+clean_env() ->
+    case os:type() of
+        {unix, darwin} ->
+            os:cmd("purge");
+        {unix, linux} ->
+            io:format("if not root or called with sudo, this may fail~n"),
+            os:cmd("echo 3 >/proc/sys/vm/drop_caches");
+        _ ->
+            halt("unknown os")
+    end.
+
+
+ensure_and_load_bitcask(BranchDir) ->
+    Path = BranchDir ++ "/ebin/",
+    Modlist = filelib:fold_files(Path, 
+                                 ".*.beam", false, 
+                                 fun(X, Acc) ->
+                                         Mod0 = filename:rootname(filename:basename(X)),
+                                         Mod = list_to_atom(Mod0),
+                                         [Mod | Acc]
+                                 end, []),
+    code:add_path(Path),
+    lists:map(fun code:load_abs/1, Modlist),
+    code:del_path(Path),
+    application:start(bitcask),
+    application:set_env(bitcask, io_mode, erlang),
+    Modlist.
+        
+cleanup(Modlist) ->
+    [begin 
+         code:delete(M),
+         code:purge(M)
+     end ||
+        M <- Modlist].

--- a/test/bcfold_setup
+++ b/test/bcfold_setup
@@ -1,0 +1,52 @@
+#! /usr/bin/env escript 
+
+main([BitcaskDir, DataDir]) ->
+    load_bitcask(BitcaskDir),
+    make_small(DataDir),
+    make_medium(DataDir),
+    make_large(DataDir),
+    make_cs(DataDir).
+       
+
+load_bitcask(Dir) ->
+    Path = Dir ++ "/ebin/",
+    Modlist = filelib:fold_files(Path, 
+                                 ".*.beam", false, 
+                                 fun(X, Acc) ->
+                                         Mod0 = filename:rootname(filename:basename(X)),
+                                         Mod = list_to_atom(Mod0),
+                                         [Mod | Acc]
+                                 end, []),
+    code:add_path(Path),
+    lists:map(fun code:load_abs/1, Modlist).
+
+
+make_small(Dir) ->
+    make_dir(Dir++"/small/", 32, 100).
+
+make_medium(Dir) ->
+    make_dir(Dir++"/medium/", 32, 2048).
+
+make_large(Dir) ->
+    make_dir(Dir++"/large/", 32, 50*1024).
+
+make_cs(Dir) ->
+    make_dir(Dir++"/cs/", 32, 1024*1024).
+
+make_dir(Dir, KeySz, BinSz) ->
+    Ref = bitcask:open(Dir, [read_write]),
+
+    %% header size + key size + binary size + ext term format overhead
+    BinarySize = 14 + KeySz + BinSz + 12,
+    %%        1GB
+    NumObjs = (1073741824 div BinarySize) + 1,
+    Key = crypto:rand_bytes(KeySz),
+    Bin = crypto:rand_bytes(BinSz),
+    [bitcask:put(Ref, <<Key/binary,X:32>>, Bin) ||
+        X <- lists:seq(1, NumObjs)],
+    bitcask:close(Ref).
+
+
+
+    
+    


### PR DESCRIPTION
This patch rewrites all of the file folds as subfolds of a function that folds over adaptively-sized chunks of the file in question, using return values as a simple protocol to communicate with the main folding function.

Some simple benchmarking.  See test/bcfold_setup for info on key and value sizes.

```
pevm-fast-fold:

Report for run: small
Open:                     23843056
Datafile Key Fold:         8119489   6795835
Datafile Fold:            31599952   6795835

Report for run: medium
Open:                      1866682
Datafile Key Fold:         6934109    509849
Datafile Fold:             9501606    509849

Report for run: large
Open:                       205041
Datafile Key Fold:         7065257     20948
Datafile Fold:             8051616     20948

Report for run: cs
Open:                       150339
Datafile Key Fold:          573293      1024
Datafile Fold:             8601723      1024

master:

Report for run: small
Open:                    298579027
Datafile Key Fold:       397753135   6795835
Datafile Fold:           168100962   6795835

Report for run: medium
Open:                     22597198
Datafile Key Fold:        72591363    509849
Datafile Fold:            17351239    509849

Report for run: large
Open:                      1095118
Datafile Key Fold:         9041969     20948
Datafile Fold:             7874795     20948

Report for run: cs
Open:                       210885
Datafile Key Fold:          590771      1024
Datafile Fold:             7196062      1024
```

These tests still need to be re-run on some machines with slower disks, but I wanted to get some feedback on the code because I am concerned with the fragility/complexity of the current interface.
