### PR TITLE
Remove warn/2 function

### DIFF
--- a/src/bitcask_file.erl
+++ b/src/bitcask_file.erl
@@ -115,7 +115,7 @@ handle_call({file_open, Owner, Filename, Opts}, _From, State) ->
                {_, true} ->
                    [read, write, exclusive, raw, binary]
            end,
-    [warn("Bitcask file option '~p' not supported~n", [Opt])
+    [error_logger:warning_msg("Bitcask file option '~p' not supported~n", [Opt])
      || Opt <- [o_sync],
         proplists:get_bool(Opt, Opts)],
     case file:open(Filename, Mode) of
@@ -190,6 +190,3 @@ check_owner({Pid, _Mref}, #state{owner=Owner}) ->
             throw(owner_invariant_failed),
             ok
     end.
-
-warn(Fmt, Args) ->
-    error_logger:warning_msg(Fmt, Args).


### PR DESCRIPTION
It's better just to call error_logger:warning_msg/2 here.
See also commit f9a10697bcf254c6568e49f0dc3ddaed5c9caae5

Signed-off-by: Peter Lemenkov lemenkov@gmail.com
