### PR TITLE
remove unused header

### DIFF
--- a/c_src/bitcask_nifs.c
+++ b/c_src/bitcask_nifs.c
@@ -36,7 +36,6 @@
 #include "murmurhash.h"
 
 #include <stdio.h>
-#include <stdbool.h>
 
 #ifdef BITCASK_DEBUG
 #include <stdarg.h>


### PR DESCRIPTION
should fix the solaris issue; in the end, usage of stdbool was refactored away.
