### PR TITLE
Enable definition of multiple merge windows per node [JIRA: RIAK-2730]

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,7 @@
 {port_specs, [{"priv/bitcask.so", ["c_src/*.c"]}]}.
 
 {deps, [
-        {meck, ".*", {git, "git://github.com/eproxus/meck"}}
+        {meck, ".*", {git, "git://github.com/basho/meck", {tag, "0.8.1"}}}
        ]}.
 
 {port_env, [


### PR DESCRIPTION
In order to limit the potential impact of merging, it is often recommended to use non-overlapping, staggered merge windows. This currently means relying on a single merge window per node, leading to increased disk usage between windows due to the lack of merging activity.

This PR makes it possible to define a list of merge windows for a node, allowing the creation of multiple shorter merge windows for each node, potentially reducing the time between merges.

The list of merge windows can be specified as follows in the app.config file:

`{merge_window, [{1, 1},{7, 7},{13, 13},{19, 19}]},`
