### PR TITLE
lazily create merge files to avoid creation of empty files

### DIFF
--- a/src/bitcask.erl
+++ b/src/bitcask.erl
@@ -588,10 +588,6 @@ merge1(Dirname, Opts, FilesToMerge, ExpiredFiles) ->
                                             Acc
                                     end
                             end, {[],[]}, InFiles1),
-    %% Setup our first output merge file and update the merge lock accordingly
-    {ok, Outfile} = bitcask_fileops:create_file(Dirname, Opts),
-    ok = bitcask_lockops:write_activefile(
-           Lock, bitcask_fileops:filename(Outfile)),
 
     %% Initialize the other keydirs we need.
     {ok, DelKeyDir} = bitcask_nifs:keydir_new(),
@@ -602,7 +598,7 @@ merge1(Dirname, Opts, FilesToMerge, ExpiredFiles) ->
                       max_file_size = get_opt(max_file_size, Opts),
                       input_files = InFiles,
                       merge_start = MergeStart,
-                      out_file = Outfile,
+                      out_file = fresh,  % will be created when needed
                       merged_files = [],
                       partial = Partial,
                       live_keydir = LiveKeyDir,
@@ -617,8 +613,13 @@ merge1(Dirname, Opts, FilesToMerge, ExpiredFiles) ->
     State1 = merge_files(State),
 
     %% Make sure to close the final output file
-    ok = bitcask_fileops:sync(State1#mstate.out_file),
-    ok = bitcask_fileops:close(State1#mstate.out_file),
+    case State1#mstate.out_file of
+        fresh ->
+            ok;
+        Outfile ->
+            ok = bitcask_fileops:sync(Outfile),
+            ok = bitcask_fileops:close(Outfile)
+    end,
 
     %% Close the original input files, schedule them for deletion,
     %% close keydirs, and release our lock
@@ -627,11 +628,6 @@ merge1(Dirname, Opts, FilesToMerge, ExpiredFiles) ->
     FileNames = [F#filestate.filename || F <- State#mstate.input_files ++ ExpiredFilesFinished],
     [catch set_setuid_bit(F) || F <- FileNames],
     bitcask_merge_delete:defer_delete(Dirname, IterGeneration, FileNames),
-    if InFiles == [] ->
-            bitcask_fileops:delete(Outfile);
-        true ->
-            ok
-    end,
 
     %% Explicitly release our keydirs instead of waiting for GC
     bitcask_nifs:keydir_release(LiveKeyDir),
@@ -1120,7 +1116,17 @@ inner_merge_write(K, V, Tstamp, OldFileId, OldOffset, State) ->
                        NewFileName),
                 State#mstate { out_file = NewFile };
             ok ->
-                State
+                State;
+            fresh ->
+                %% create the output file and take the lock.
+                {ok, NewFile} = bitcask_fileops:create_file(
+                                  State#mstate.dirname,
+                                  State#mstate.opts),
+                NewFileName = bitcask_fileops:filename(NewFile),
+                ok = bitcask_lockops:write_activefile(
+                       State#mstate.merge_lock,
+                       NewFileName),
+                State#mstate { out_file = NewFile }                
         end,
     
     {ok, Outfile, Offset, Size} =
@@ -1814,9 +1820,9 @@ expire_merge_test() ->
     timer:sleep(1100),
     ok = merge("/tmp/bc.test.mergeexpire",[{expiry_secs,1}]),
 
-    %% Verify we've now only got one file
+    %% With lazy merge file creation there will be no files.
     ok = bitcask_merge_delete:testonly__delete_trigger(),
-    1 = length(readable_files("/tmp/bc.test.mergeexpire")),
+    0 = length(readable_files("/tmp/bc.test.mergeexpire")),
 
     %% Make sure all the data is present
     B = bitcask:open("/tmp/bc.test.mergeexpire"),


### PR DESCRIPTION
in situations with few hot keys, you can produce a whole ton of empty data files.  when all of keys in a partial merge have already expired, a data file will be created and nothing will ever be put into it.  These files aren't cleaned up until reopen, so they can cause problems when may of them accumulate over time.  

Moving to a lazy file creation strategy avoids this problem.

fixes #113 

Testing notes: 

See #116 for test setup.

The symptom here is a buildup of 0 length data files paired with empty 18 byte hint files. These should be readily apparent in the setup given above, they will begin to appear as soon as merges start, and will build up linearly over time.  On an overnight run, tens of thousands can build up.

None should appear (except very briefly, as new files are started) with this patch applied.
