### PR TITLE
Fix iterator generation increment

### DIFF
--- a/c_src/bitcask_nifs.c
+++ b/c_src/bitcask_nifs.c
@@ -1625,9 +1625,12 @@ ERL_NIF_TERM bitcask_nifs_keydir_itr_release(ErlNifEnv* env, int argc, const ERL
         handle->keydir->keyfolders--;
 
         // If last iterator closing, unfreeze keydir and merge pending entries.
-        if (handle->keydir->keyfolders == 0 && handle->keydir->pending != NULL)
+        if (handle->keydir->keyfolders == 0)
         {
-            merge_pending_entries(env, handle->keydir);
+            if (handle->keydir->pending != NULL)
+            {
+                merge_pending_entries(env, handle->keydir);
+            }
             handle->keydir->iter_generation++;
         }
         UNLOCK(handle->keydir);


### PR DESCRIPTION
iter_generation should increment every time the number of iterators
reaches zero. The existing code only does it when that happens AND the
keydir was frozen.  iter_generation is used in the delete worker to
avoid deleting files that are still used by a snapshot present in the
keydir when iterators are used.  So the current code may postpone
deleting files for potentially a long time if the keydir doesn't reach
the point where it needs to freeze.

This behavior was introduced with multifolds. Before that, keydirs unfreezing
and number of iterators going to zero was basically the same event.
