### PR TITLE
multifold test stabilization

### DIFF
--- a/src/bitcask.erl
+++ b/src/bitcask.erl
@@ -1705,6 +1705,7 @@ fold_visits_frozen_test_() ->
 
 fold_visits_frozen_test(RollOver) ->
     Cask = "/tmp/bc.test.frozenfold",
+    os:cmd("rm -r " ++ Cask),
     B = init_dataset(Cask, default_dataset()),
     try
         Ref = (get_state(B))#bc_state.keydir,
@@ -1827,6 +1828,8 @@ finish_worker_loop(Pid) ->
 fold_visits_unfrozen_test(RollOver) ->
     %%?debugFmt("rollover is ~p~n", [RollOver]),
     Cask = "/tmp/bc.test.unfrozenfold",
+    os:cmd("rm -r "++Cask),
+
     bitcask_time:test__set_fudge(1),
     B = init_dataset(Cask, default_dataset()),
     try


### PR DESCRIPTION
We've been seeing some nondeterministic test failures after the
multifold stuff went in, this patch is an attempt to make them stop
happening.
- bitcask_nifs: Prior to multifold, keydir_itr_many_update_test() and
  keydir_itr_many_out_of_date_test() tested different things.  They're
  also subject to a race condition that the test bots seem to hit all
  the time.  As of multifold, they become the same test, so rename,
  de-race, and deduplicate.
- bitcask: The fold_visits_frozen_test() and
  fold_visits_unfrozen_test() don't clean up their disk state between
  runs.  We've been seeing some timeouts, adding this cleanup to
  hopefully stop it from happening.
