### PR TITLE
add explicit multifold test

### DIFF
--- a/src/bitcask.erl
+++ b/src/bitcask.erl
@@ -2562,9 +2562,9 @@ fold_itercount_test() ->
 
 
 fold_lockstep_test_() ->
-    {timeout, 100, fun fold_lockstep_test/0}.
+    {timeout, 100, fun fold_lockstep_body/0}.
 
-fold_lockstep_test() ->
+fold_lockstep_body() ->
     Cask = "/tmp/bc.lockstep-test/",
     os:cmd("rm -rf "++Cask),
     Ref = bitcask:open(Cask, [read_write]),


### PR DESCRIPTION
Although there are several tests that test it implicitly, we don't have a test that explicitly checks that multifold is happening, is happening in parallel, and that multiple snapshots are correctly being kept.  

The test preloads the keydir to some fullness where we know we aren't going to run into a freeze, then starts several successive folders.  It then allows one iteration from each of the fold processes in order until there are no more iterations to be done.  Finally, it checks that each of the returned lists is the correct length.

This test could be a little more careful and check the fold contents, but I think that length is a reasonable stand-in.
