### PR TITLE
Restore fix to timestamp test

### DIFF
--- a/src/bitcask_time.erl
+++ b/src/bitcask_time.erl
@@ -31,6 +31,7 @@ tstamp() ->
     test__get(?KEY).
 
 test__set_fudge(Amount) ->
+    test__clear_fudge(),
     application:set_env(bitcask, ?KEY, Amount).
 
 test__get_fudge() ->


### PR DESCRIPTION
This was lost in the naughty force push that ate everybody. The original
commit is 324aab1c6efdb1c914e1bb7485bada2eac29c154.

This clears the time fudge and prevents code from using real timestamps
when fake ones were intended to verify the test.

This can be used to verify the fix (from Scott's original comment):

```
rebar skip_deps=true -v eunit suites=bitcask tests=roundtrip_test,update_tstamp_stats_test
```
