### PR TITLE
add warnings as errors to the nif build flags

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -6,19 +6,23 @@
         {cuttlefish, ".*", {git, "git://github.com/basho/cuttlefish.git", {branch, "develop"}}}
        ]}.
 
-{port_env, [
-             %% Solaris specific flags
-             {"solaris.*-64$", "CFLAGS", "-D_REENTRANT -m64"},
-             {"solaris.*-64$", "LDFLAGS", "-m64"},
+{port_env, 
+ [
+  {"DRV_CFLAGS", 
+   "-g -Wall -fPIC -errors $ERL_CFLAGS"},
 
-             %% OS X Leopard flags for 64-bit
-             {"darwin9.*-64$", "CFLAGS", "-m64"},
-             {"darwin9.*-64$", "LDFLAGS", "-arch x86_64"},
+  %% Solaris specific flags
+  {"solaris.*-64$", "CFLAGS", "-D_REENTRANT -m64"},
+  {"solaris.*-64$", "LDFLAGS", "-m64"},
 
-             %% OS X Snow Leopard flags for 32-bit
-             {"darwin10.*-32$", "CFLAGS", "-m32"},
-             {"darwin10.*-32$", "LDFLAGS", "-arch i386"}
-           ]}.
+  %% OS X Leopard flags for 64-bit
+  {"darwin9.*-64$", "CFLAGS", "-m64"},
+  {"darwin9.*-64$", "LDFLAGS", "-arch x86_64"},
+
+  %% OS X Snow Leopard flags for 32-bit
+  {"darwin10.*-32$", "CFLAGS", "-m32"},
+  {"darwin10.*-32$", "LDFLAGS", "-arch i386"}
+ ]}.
 
 {erl_opts, [debug_info, warnings_as_errors]}.
 {eunit_opts, [verbose]}.


### PR DESCRIPTION
Turns out that the rebar problems I was seeing is because rebar uses the somewhat brittle-feeling strategy of replacing all of the default DRV_CFLAGS with the ones that you specify, so you have to add all of them to get any changes made.  I reformatted everything because one of the lines was long.

I played with various pedantic and -std modes, but the scope of changes didn't seem worth it, especially for pedantic.

Fixes #159 
