### PR TITLE
Invalid hintfile error message is too severe

### DIFF
--- a/src/bitcask_fileops.erl
+++ b/src/bitcask_fileops.erl
@@ -336,8 +336,8 @@ fold_keys(#filestate{fd=Fd}=State, Fun, Acc, recovery, _, true) ->
             Acc0;
         {error, Reason} ->
             HintFile = hintfile_name(State),
-            error_logger:error_msg("Hintfile '~s' failed fold: ~p\n",
-                                   [HintFile, Reason]),
+            error_logger:warning_msg("Hintfile '~s' failed fold: ~p\n",
+                                     [HintFile, Reason]),
             fold_keys_loop(Fd, 0, Fun, Acc);
         Acc1 ->
             Acc1
@@ -590,9 +590,9 @@ fold_hintfile_loop(<<Tstamp:?TSTAMPFIELD, KeySz:?KEYSIZEFIELD,
             fold_hintfile_loop(Rest, Fun, Acc, 
                                Consumed, Args, EOI);
         false ->
-            error_logger:error_msg("Hintfile '~s' contains pointer ~p ~p "
-                                   "that is greater than total data size ~p\n",
-                                   [HintFile, Offset, TotalSz, DataSize]),
+            error_logger:warning_msg("Hintfile '~s' contains pointer ~p ~p "
+                                     "that is greater than total data size ~p\n",
+                                     [HintFile, Offset, TotalSz, DataSize]),
             {error, {trunc_hintfile, Acc0}}
     end;
 %% error case where we've gotten to the end of the file without the CRC match


### PR DESCRIPTION
Invalid hintfiles happen all the time and it's ok. We should use warning or notice for:

```
2014-04-16 16:45:46.838 [error] <0.2110.0> Hintfile './data/fs_chunks/1370157784997721485815954530671515330927436759040/3.bitcask.hint' invalid
```
