### PR TITLE
Bugfix/key transform crash

### DIFF
--- a/src/bitcask.erl
+++ b/src/bitcask.erl
@@ -1908,9 +1908,12 @@ expiry_merge([], _LiveKeyDir, _KT, Acc) ->
     Acc;
 expiry_merge([File | Files], LiveKeyDir, KT, Acc0) ->
     FileId = bitcask_fileops:file_tstamp(File),
-    Fun = fun(K, Tstamp, {Offset, _TotalSz}, Acc) ->
-                bitcask_nifs:keydir_remove(LiveKeyDir, KT(K), Tstamp, FileId, Offset),
-                Acc
+    Fun = fun({tombstone, _}, _, _, Acc) ->
+                  Acc;
+             (K, Tstamp, {Offset, _TotalSz}, Acc) ->
+                  bitcask_nifs:keydir_remove(LiveKeyDir, KT(K), Tstamp, FileId,
+                                             Offset),
+                  Acc
         end,
     case bitcask_fileops:fold_keys(File, Fun, ok, default) of
         {error, Reason} ->


### PR DESCRIPTION
When merging completely expired files, we fold over them issuing
conditional keydir deletes on the entries of the file. That way, if any
of them are still present in the keydir, they will be deleted now
instead of the usual lazy delete on read, when we detect they are
expired.

Previously, the code was not accounting for the new {tombstone, Key}
return format when folding over the hintfile. A recent change in 1.7.0
added a tombstone bit flag to hintfiles, so now we can tell we are
dealing with a tombstone without inspecting the data file.  The tuple was 
being passed whole to the userdefined key transformation function, causing
a crash. With this change, we simply skip over tombstones. It makes no
sense to try to delete them from the keydir.

This fixes basho/bitcask#185 in the 1.7 branch (Bitcask shipped with Riak 2.0.0).
When merged, this should be ported or merged to the develop branch also.
