### PR TITLE
Fix scan error deadlock

### DIFF
--- a/src/bitcask.erl
+++ b/src/bitcask.erl
@@ -1241,6 +1241,7 @@ init_keydir(Dirname, WaitTime, ReadWriteModeP, KT) ->
 
             case ScanResult of
                 {error, _} ->
+                    ok = bitcask_nifs:keydir_release(KeyDir),
                     ScanResult;
                 _ ->
                     %% Now that we loaded all the data, mark the keydir as ready


### PR DESCRIPTION
If a file scan error happens during a Bitcask open operation, remember
to release the newly created keydir.  Before, that keydir was left
behind. Subsequent open operations would see it, see that it was not
ready yet and try to wait for it to load. But this would never happen,
alas.

If a scan error happens on opening a new directory, please release the
newly created keydir so other open operations have a chance to succeed.

This fixes issue https://github.com/basho/bitcask/issues/187

The first commit contains a new failing tests to demonstrate, and the
second commit contains the fix.
