### PR TITLE
Unpin cuttlefish from tag

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -3,7 +3,7 @@
 
 {deps, [
         {meck, "0.8.1", {git, "git://github.com/basho/meck.git", {tag, "0.8.1"}}},
-        {cuttlefish, ".*", {git, "git://github.com/basho/cuttlefish.git", {tag, "2.0.0"}}}
+        {cuttlefish, ".*", {git, "git://github.com/basho/cuttlefish.git", {branch, "2.0"}}}
        ]}.
 
 {port_env,


### PR DESCRIPTION
Pointing to branch instead. This should allow basho/riak_repl#622 to
pull the correct cuttlefish dependency and pass tests.
