### PR TITLE
update meck dependency to 0.8.2

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -2,7 +2,7 @@
 {port_specs, [{"priv/bitcask.so", ["c_src/*.c"]}]}.
 
 {deps, [
-        {meck, "0.8.1", {git, "git://github.com/basho/meck.git", {tag, "0.8.1"}}},
+        {meck, "0.8.2", {git, "git://github.com/basho/meck.git", {tag, "0.8.2"}}},
         {cuttlefish, ".*", {git, "git://github.com/basho/cuttlefish.git", {branch, "develop"}}}
        ]}.
 


### PR DESCRIPTION
Duplicate of https://github.com/basho/bitcask/pull/182 but in develop branch.