### PR TITLE
Bump meck dependency on develop to match folsom.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -2,7 +2,7 @@
 {port_specs, [{"priv/bitcask.so", ["c_src/*.c"]}]}.
 
 {deps, [
-        {meck, "0.8.1", {git, "git://github.com/basho/meck.git", {tag, "0.8.1"}}},
+        {meck, "0.8.2", {git, "git://github.com/basho/meck.git", {tag, "0.8.2"}}},
         {cuttlefish, ".*", {git, "git://github.com/basho/cuttlefish.git", {branch, "develop"}}}
        ]}.
 


### PR DESCRIPTION
The folsom dependency on develop is now at the 0.8.2 tag of meck;
advance the bitcask tag to allow riak_kv and yokozuna to compile.