### PR TITLE
Pin cuttlefish to tag 2.0.1 explicitly

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -4,7 +4,7 @@
 
 {deps, [
         {meck, "0.8.2", {git, "git://github.com/basho/meck.git", {tag, "0.8.2"}}},
-        {cuttlefish, ".*", {git, "git://github.com/basho/cuttlefish.git", {branch, "develop"}}}
+        {cuttlefish, ".*", {git, "git://github.com/basho/cuttlefish.git", {tag, "2.0.1"}}}
        ]}.
 
 {port_env,


### PR DESCRIPTION
**TODO**: After this is merged. Decide what tag we're going to use - historically bitcask has had a tag pegged to a specific riak release.