### PR TITLE
Remove incorrect option.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -10,7 +10,7 @@
 {port_env,
  [
   {"DRV_CFLAGS",
-   "-g -Wall -fPIC -errors $ERL_CFLAGS"},
+   "-g -Wall -fPIC $ERL_CFLAGS"},
 
   %% Solaris specific flags
   {"solaris.*-64$", "CFLAGS", "-D_REENTRANT -m64"},


### PR DESCRIPTION
Both gcc and clang do not support a -errors flag, so remove it to
prevent errors about using an undefined flag.