### PR TITLE
Erlang 18.0 now() fix.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -4,7 +4,7 @@
 
 {deps, [
         {meck, "0.8.2", {git, "git://github.com/basho/meck.git", {tag, "0.8.2"}}},
-        {cuttlefish, ".*", {git, "git://github.com/basho/cuttlefish.git", {tag, "2.0.1"}}}
+        {cuttlefish, ".*", {git, "git://github.com/basho/cuttlefish.git", {branch, "develop"}}}
        ]}.
 
 {port_env,

--- a/src/bitcask_timestamp.erl
+++ b/src/bitcask_timestamp.erl
@@ -1,0 +1,11 @@
+-module(bitcask_timestamp).
+-compile(nowarn_deprecated_function).
+-export([timestamp/0]).
+
+timestamp() ->
+    try
+	erlang:timestamp()
+    catch
+	error:undef ->
+	    erlang:now()
+    end.

--- a/test/bitcask_pr156.erl
+++ b/test/bitcask_pr156.erl
@@ -34,7 +34,7 @@ pr156_regression2_test_() ->
      end}.
 
 pr156_regression1(X) ->
-    io:format("pr156_regression1 ~p at ~p\n", [X, now()]),
+    io:format("pr156_regression1 ~p at ~p\n", [X, bitcask_timestamp:timestamp()]),
     token:next_name(),
     Dir = ?BITCASK ++ ".1." ++ token:get_name(),
     os:cmd("rm -rf " ++ Dir),
@@ -74,7 +74,7 @@ pr156_regression1(X) ->
 %% r1s11.bos1 executes each of N iterations in about 1500 msec.
 
 pr156_regression2(X) ->
-    io:format("pr156_regression2 ~p at ~p\n", [X, now()]),
+    io:format("pr156_regression2 ~p at ~p\n", [X, bitcask_timestamp:timestamp()]),
     token:next_name(),
     Dir = ?BITCASK ++ ".2." ++ token:get_name(),
     os:cmd("rm -rf " ++ Dir),

--- a/test/bitcask_pulse.erl
+++ b/test/bitcask_pulse.erl
@@ -276,7 +276,7 @@ host() ->
 
 %% Generate a most likely unique node name
 unique_name() ->
-  {A, B, C} = erlang:now(),
+  {A, B, C} = bitcask_timestamp:timestamp(),
   list_to_atom(lists:concat([integer_to_list(A), "-",
                              integer_to_list(B), "-",
                              integer_to_list(C)])).
@@ -1021,7 +1021,7 @@ custom_shrink(CE=[_,Seed|_], [C|Cs], Repeat) ->
   end.
 
 check_many(C, N) ->
-  check_many(erlang:now(), C, N).
+  check_many(bitcask_timestamp:timestamp(), C, N).
 
 check_many(_, _, 0) -> true;
 check_many(Seed, C0, N) ->
@@ -1037,7 +1037,7 @@ mk_counterexample(CE = [Cmds, _Seed]) when is_list(Cmds) ->
   CE;
 mk_counterexample(Cmds) ->
   S = state_after(?MODULE, Cmds),
-  [Cmds, erlang:now(),
+  [Cmds, bitcask_timestamp:timestamp(),
    [ {0, []} | [ {I, []}
                  || I <- lists:seq(1, length(S#state.readers)) ] ]
    ++ [ {errors, []}, {events, []} ] ].
@@ -1047,7 +1047,7 @@ mk_counterexample(Cmds, Seed) ->
   [Cmds, Seed, Conj].
 
 foo() ->
-  erlang:now().
+  bitcask_timestamp:timestamp().
 
 %% Helper functions
 fold(F, X) ->

--- a/test/bitcask_qc.erl
+++ b/test/bitcask_qc.erl
@@ -158,7 +158,7 @@ prop_merge() ->
          ?FORALL({Ops, M1, M2}, {eqc_gen:non_empty(list(ops(Keys, Values))),
                                  choose(1,128), choose(1,128)},
                  begin
-                     Tm = tuple_to_list(now()),
+                     Tm = tuple_to_list(bitcask_timestamp:timestamp()),
                      Dir = lists:flatten(
                              io_lib:format(
                                "/tmp/bc.prop.merge.~w.~w.~w", Tm)),

--- a/test/event_logger.erl
+++ b/test/event_logger.erl
@@ -128,6 +128,6 @@ add_event(#event{timestamp = Now, data = Data}, State) ->
   State#state{ events = [Event|State#state.events] }.
 
 timestamp() ->
-  {A, B, C} = erlang:now(),
+  {A, B, C} = bitcask_timestamp:timestamp(),
   1000000 * (1000000 * A + B) + C.
 

--- a/test/generic_qc_fsm.erl
+++ b/test/generic_qc_fsm.erl
@@ -163,7 +163,7 @@ prop(FI_enabledP, VerboseP) ->
                 faulterl_nif:poke("bc_fi_enabled", 0, <<0:8/native>>, false),
                 [catch erlang:garbage_collect(Pid) || Pid <- erlang:processes()],
 
-                {Ta, Tb, Tc} = now(),
+                {Ta, Tb, Tc} = bitcask_timestamp:timestamp(),
                 TestDir = ?TEST_DIR ++ lists:flatten(io_lib:format(".~w.~w.~w", [Ta, Tb, Tc])),
                 ok = file:make_dir(TestDir),
                 Env = [{parameter_test_dir, TestDir}],
@@ -443,7 +443,7 @@ fold_all(H) ->
                 [{K,V}|Acc]
         end,
     io:format(user, "<f", []),
-    ID = now(),
+    ID = bitcask_timestamp:timestamp(),
     event_logger:event({fold, start, ID}),
     case bitcask:fold(H, F, []) of
         {error, _} ->

--- a/test/token.erl
+++ b/test/token.erl
@@ -50,6 +50,6 @@ loop(Name) ->
   end.
 
 mk_name() ->
-  {A, B, C} = erlang:now(),
+  {A, B, C} = bitcask_timestamp:timestamp(),
   lists:concat([A, "-", B, "-", C]).
 


### PR DESCRIPTION
Make bitcask work in OTP 18.0.

The rebar.config change temporarily depends on {branch, "develop"} of cuttlefish. When it's merged, it should really depend on a new tag on cuttlefish. I need the OTP 18 changes there that are newer than any current tag.

This fixes the OTP 18 deprecation warnings for erlang:now(), which are fatal due to warnings_as_errors in the erl_opts setting in rebar.config.

The bitcask_timestamp.erl code is from http://www.erlang.org/doc/apps/erts/time_compat.erl

The modified bitcask application passes "make test" in [basho/otp](https://github.com/basho/otp) branches [basho-otp-16](https://github.com/basho/otp/tree/basho-otp-16), [basho-otp-17](https://github.com/basho/otp/tree/basho-otp-17), and [basho-otp-18](https://github.com/basho/otp/tree/basho-otp-18). "All 81 tests passed."
