### PR TITLE
Update cuttlefish to 2.0.5

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -4,7 +4,7 @@
 
 {deps, [
         {meck, "0.8.2", {git, "git://github.com/basho/meck.git", {tag, "0.8.2"}}},
-        {cuttlefish, ".*", {git, "git://github.com/basho/cuttlefish.git", {tag, "2.0.1"}}}
+        {cuttlefish, ".*", {git, "git://github.com/basho/cuttlefish.git", {tag, "2.0.5"}}}
        ]}.
 
 {port_env,


### PR DESCRIPTION
This is required to update lager to version 2.2.0