### PR TITLE
has_valid_hintfile leaked a hintfile file descriptor [JIRA: RIAK-2316]

### DIFF
--- a/src/bitcask_fileops.erl
+++ b/src/bitcask_fileops.erl
@@ -483,9 +483,13 @@ has_valid_hintfile(State) ->
     HintFile = hintfile_name(State),
     case bitcask_io:file_open(HintFile, [readonly, read_ahead]) of
         {ok, HintFd} ->
-            {ok, HintI} = read_file_info(HintFile),
-            HintSize = HintI#file_info.size,
-            hintfile_validate_loop(HintFd, 0, HintSize);
+            try
+                {ok, HintI} = read_file_info(HintFile),
+                HintSize = HintI#file_info.size,
+                hintfile_validate_loop(HintFd, 0, HintSize)
+            after
+                bitcask_io:file_close(HintFd)
+            end;
         _ ->
             false
     end.


### PR DESCRIPTION
The ```has_valid_hintfile``` function opened the file, then recursively called
```hintfile_validate_loop``` until the end of file or error.  Either way
it does not close the file.

```has_valid_hintfile``` is called as part of opening a bitcask
via ```fold_keys(..., recovery, ...)``` via ```bitcask:scan_keyfiles/5```
so the descriptors are leaked each time the bitcask is opened.

Fixed by adding a try/after block around the ```hintfile_validate_loop/3```

Passed ```./rebar eunit``` locally

```
  All 95 tests passed.
```