### PR TITLE
Increment Bitcask OTP version string for new tag

### DIFF
--- a/src/bitcask.app.src
+++ b/src/bitcask.app.src
@@ -1,7 +1,7 @@
 {application, bitcask,
  [
   {description, ""},
-  {vsn, "1.7.2"},
+  {vsn, "1.7.4"},
   {modules, []},
   {registered, []},
   {applications, [


### PR DESCRIPTION
This is maybe not strictly necessary, since we mostly only use this version string to check on-disk format and decide if we need to upgrade, and as far as I'm aware the on-disk format hasn't changed since 1.6. But, always good to be correct and accurate with stuff like this.

Also, note that we forgot to bump the version string for the previous tag, which is why we're going straight from 1.7.2 to 1.7.4.