### PR TITLE
Drop unneeded eunit include

### DIFF
--- a/src/bitcask_file.erl
+++ b/src/bitcask_file.erl
@@ -23,8 +23,6 @@
 -compile(export_all).
 -behaviour(gen_server).
 
--include_lib("eunit/include/eunit.hrl").
-
 -ifdef(PULSE).
 -compile({parse_transform, pulse_instrument}).
 -endif.


### PR DESCRIPTION
This include isn't necessary. It was introduced in commit a23d541d714f6ffda1052e488bb13759e93aa092 and looks like a leftover.

The problem is that this include adds additional dependency on eunit, if the resulting BEAM-files are checked by static checkers. Minor one but still.
