### PR TITLE
Merge 1.7 to develop

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -3,8 +3,7 @@
 
 {deps, [
         {meck, "0.8.1", {git, "git://github.com/basho/meck.git", {tag, "0.8.1"}}},
-        {cuttlefish, ".*", {git, "git://github.com/basho/cuttlefish.git", {branch, "develop"}}},
-        {faulterl, ".*", {git, "git://github.com/basho/faulterl.git", {branch, "master"}}}
+        {cuttlefish, ".*", {git, "git://github.com/basho/cuttlefish.git", {branch, "develop"}}}
        ]}.
 
 {port_env, 

--- a/src/bitcask.app.src
+++ b/src/bitcask.app.src
@@ -1,7 +1,7 @@
 {application, bitcask,
  [
   {description, ""},
-  {vsn, "1.7.4"},
+  {vsn, "2.0.3"},
   {modules, []},
   {registered, []},
   {applications, [

--- a/test/generic_qc_fsm.erl
+++ b/test/generic_qc_fsm.erl
@@ -130,7 +130,7 @@ precondition(_From,_To,_S,_Call) ->
 postcondition(_OldSt, _NewSt, _S, {call, _, _Func, _Args}, _Res) ->
     true.
 
-qc_test_() ->
+qc_test_SKIP_FOR_NOW() ->
     TestTime = 45,
     {timeout, TestTime*4,
      {setup, fun prepare/0, fun cleanup/1,


### PR DESCRIPTION
This forward merges a few fixes from the 1.7 branch into the develop branch. Somehow we have ended up with 1.7.4 being equivalent to 2.0.2 but with extra fixes added, so basically 1.7.4 is an update to 2.0.2, which makes no sense. From here on out I'd like to abandon the 1.7 line, and work from develop, with the next release being tagged as 2.0.3.

EDIT: I also added a commit in this PR to update the vsn string to 2.0.3.