### PR TITLE
fix(typo): keydir order is different to current's implement

### DIFF
--- a/c_src/pulse_c_send.c
+++ b/c_src/pulse_c_send.c
@@ -28,16 +28,16 @@ ERL_NIF_TERM set_pulse_pid(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]){
     }
 
     enif_get_local_pid(env, argv[0], THE_PULSE_PID);
-    
+
     return ATOM_OK;
 }
 
 int  pulse_send(ErlNifEnv* env, ErlNifPid* dest_pid,
                 ErlNifEnv* msg_env, ERL_NIF_TERM msg,
                 char* file, int line){
-    ERL_NIF_TERM t_self = 
+    ERL_NIF_TERM t_self =
         enif_make_pid(msg_env, enif_self(msg_env, (ErlNifPid *)malloc(sizeof(ErlNifPid))));
-    ERL_NIF_TERM t_src_loc = 
+    ERL_NIF_TERM t_src_loc =
         enif_make_tuple2(msg_env, enif_make_string(msg_env, file, ERL_NIF_LATIN1),
                                   enif_make_int(msg_env, line));
     ERL_NIF_TERM t_args = enif_make_list(msg_env, 2, enif_make_pid(msg_env, dest_pid), msg);

--- a/src/bitcask_file.erl
+++ b/src/bitcask_file.erl
@@ -147,7 +147,7 @@ handle_call({file_open, Owner, Filename, Opts}, _From, State) ->
                                    [Filename, Reason]),
             {stop, {file_open_failed, Reason}, Error, State}
     end;
-handle_call(file_close, From, State=#state{fd=Fd}) -> 
+handle_call(file_close, From, State=#state{fd=Fd}) ->
     check_owner(From, State),
     ok = file:close(Fd),
     {stop, normal, ok, State};

--- a/src/bitcask_merge_delete.erl
+++ b/src/bitcask_merge_delete.erl
@@ -187,12 +187,12 @@ multiple_merges_during_fold_body() ->
     bitcask:merge(Dir),
     PutSome(),
     merge_until(Dir, Count1, CountSetuids),
-    
+
     SlowPid ! go_ahead,
     timer:sleep(500),
     ok = ?MODULE:testonly__delete_trigger(),
     0 = CountSetuids(),
-    
+
     ok.
 
 merge_until(Dir, MinCount, CountSetuids) ->
@@ -204,7 +204,7 @@ merge_until(Dir, MinCount, CountSetuids) ->
             timer:sleep(100),
             merge_until(Dir, MinCount, CountSetuids)
     end.
-    
+
 regression_gh82_test_() ->
     {timeout, 300, ?_assertEqual(ok, regression_gh82_body())}.
 

--- a/src/bitcask_merge_worker.erl
+++ b/src/bitcask_merge_worker.erl
@@ -85,7 +85,7 @@ init([]) ->
 
 handle_call({merge, Args0}, _From, #state { queue = Q } = State) ->
     [Dirname|_] = Args0,
-    Args1 = 
+    Args1 =
         case length(Args0) of
             3 ->
                 %% presort opts and files tuples for better matches
@@ -93,7 +93,7 @@ handle_call({merge, Args0}, _From, #state { queue = Q } = State) ->
                 [_, Opts0, Tuple0] = Args0,
                 {Files, Expired} = Tuple0,
                 Opts = lists:usort(Opts0),
-                Tuple = {lists:usort(Files), 
+                Tuple = {lists:usort(Files),
                          lists:usort(Expired)},
                 [Dirname, Opts, Tuple];
             _ ->
@@ -156,7 +156,7 @@ code_change(_OldVsn, State, _Extra) ->
 
 merge_items(New, Old) ->
     %% first element will always match
-    Dirname = element(1, New), 
+    Dirname = element(1, New),
     %% old args are already sorted
     OOpts = element(2, Old),
     NOpts = lists:usort(element(2, New)),


### PR DESCRIPTION
Hi, the implement of `bitcask:init_keydir/4` is updated, and the annotate is not updated by now.

Also strip the trailing whitespace :anchor:
