### PR TITLE
Lock cuttlefish dep to 2.0.8

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -4,7 +4,7 @@
 
 {deps, [
         {meck, "0.8.2", {git, "git://github.com/basho/meck.git", {tag, "0.8.2"}}},
-        {cuttlefish, ".*", {git, "git://github.com/basho/cuttlefish.git", {branch, "develop"}}}
+        {cuttlefish, ".*", {git, "https://github.com/basho/cuttlefish.git", {tag, "2.0.8"}}}
        ]}.
 
 {port_env,


### PR DESCRIPTION
Bring `develop` up to date with `develop-2.2`.