### PR TITLE
Use O_CREAT flag when opening files to match behavior of erlang mode

### DIFF
--- a/c_src/bitcask_nifs.c
+++ b/c_src/bitcask_nifs.c
@@ -2311,7 +2311,7 @@ ERL_NIF_TERM bitcask_nifs_lock_writedata(ErlNifEnv* env, int argc, const ERL_NIF
 
 int get_file_open_flags(ErlNifEnv* env, ERL_NIF_TERM list)
 {
-    int flags = O_RDWR | O_APPEND;
+    int flags = O_RDWR | O_APPEND | O_CREAT;
     ERL_NIF_TERM head, tail;
     while (enif_get_list_cell(env, list, &head, &tail))
     {


### PR DESCRIPTION
In specific merge cases, we attempt to open a hintfile which has been removed and in erlang mode will create the file while in NIF mode the cask crashes. Use O_CREAT to bring the modes to parity. Resolves #242 (RIAK-1890) (RIAK-2733) and #251 (RIAK-2895)