### PR TITLE
Obtain Bitcask write locks using system call `flock/2`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .eunit/*
-deps/*
+deps
 ebin
 priv/*.so
 *.o
@@ -7,3 +7,4 @@ priv/*.so
 *~
 .local_dialyzer_plt
 log/
+erl_crash.dump

--- a/test/bitcask_lockops_tests.erl
+++ b/test/bitcask_lockops_tests.erl
@@ -1,0 +1,88 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2018 Workday, Inc.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+-module(bitcask_lockops_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-export([bitcask_locker_vm_main/0]).
+
+lock_cannot_be_obtained_on_already_locked_file_within_same_os_process_test() ->
+    Dir = "/tmp",
+    Filename = bitcask_lockops:lock_filename(write,Dir),
+    ok = file_delete(Filename),
+    ok = file:write_file(Filename, ""),
+    {ok, _Lock} = bitcask_lockops:acquire(write, Dir),
+    ?assertEqual(
+       {error, locked},
+       bitcask_lockops:acquire(write, Dir)
+    ).
+
+lock_can_be_obtained_on_already_locked_file_is_unlocked_test() ->
+    Dir = "/tmp",
+    Filename = bitcask_lockops:lock_filename(write,Dir),
+    ok = file_delete(Filename),
+    ok = file:write_file(Filename, ""),
+    {ok, Lock} = bitcask_lockops:acquire(write, Dir),
+    bitcask_lockops:release(Lock),
+    ?assertMatch(
+       {ok, _},
+       bitcask_lockops:acquire(write, Dir)
+    ).
+
+lock_cannot_be_obtained_on_already_locked_file_across_os_process_test() ->
+    os:cmd("mkdir -p /tmp/lockbitcask"),
+    os:cmd("rm -rf /tmp/lockbitcask/*"),
+    %% start another erlang vm that will open the DB and obtain a write
+    %% lock, then, when we try to obtain a write lock on the current vm
+    %% it should fail.
+    Eval1 =
+        "erl -pa ebin -pa deps/*/ebin -noinput -noshell "
+            "-eval \"bitcask_lockops_tests:bitcask_locker_vm_main().\"", 
+    spawn_link(
+        fun() ->
+            Output = os:cmd(Eval1),
+            ?debugFmt("\nCMD OUTPUT: ~s", [Output])
+        end),
+    timer:sleep(1000),
+    DB = bitcask:open("/tmp/lockbitcask",[read_write]),
+    ?assertEqual(
+       {error,{error,locked}},
+       bitcask:put(DB, <<"k">>, <<"v">>)
+    ).
+
+%% entry function for another vm to lock a bitcask DB
+bitcask_locker_vm_main() ->
+    case (catch bitcask:open("/tmp/lockbitcask", [read_write,{open_timeout,1000}])) of
+        {error, Error} ->
+            io:format("ERROR: ~p", [Error]);
+        DB ->
+            %% DB is locked on the first write operation
+            ok = bitcask:put(DB, <<"k">>, <<"v">>),
+            io:format('~p',[os:getpid()]),
+            timer:sleep(3000),
+            erlang:halt()
+    end.
+
+file_delete(Filename) ->
+    case file:delete(Filename) of
+        ok -> ok;
+        {error,enoent} -> ok
+    end.
+


### PR DESCRIPTION
Previous to this change, the OS pid was used to lock the bitcask database and prevent two bitcask instances performing write operations at the same time. If the pid in the lock file is currently taken by an OS process then the bitcask DB may not be written to. Bitcask is not able to clean up the write locks because of a hard shutdown it may not be able to delete the "stale" lock file and obtain a new one for the following reasons:

- Another process takes the pid in the lock file
- Riak takes the pid in the lock file

This has been raised in issues #72, #226 and basho/riak#535.

This change uses the [flock](https://linux.die.net/man/2/flock) system call to obtain exclusive write access to the file across OS processes, as long as the other processes use flock
to obtain the lock.

The change maintains the previous behaviour where the DB can be opened even if a write lock cannot be obtained, but returns an error on write operations.

The `O_EXCL` flag has been removed from the call to `open` in the nifs because if the lock file still exists, it returns the `eexist` error but now the proof of the write lock is not the file existing but the call to `flock`.