### PR TITLE
OTP21 support

### DIFF
--- a/include/bitcask.hrl
+++ b/include/bitcask.hrl
@@ -7,13 +7,13 @@
 
 
 %% @type filestate().
--record(filestate, {mode :: 'read_only' | 'read_write',     % File mode: read_only, read_write
+-record(filestate, {mode='read_only' :: 'read_only' | 'read_write',     % File mode: read_only, read_write
                     filename :: string(), % Filename
-                    tstamp :: integer(),   % Tstamp portion of filename
-                    fd :: port(),       % File handle
-                    hintfd :: port(),   % File handle for hints
+                    tstamp=0 :: integer(),   % Tstamp portion of filename
+                    fd :: port() | undefined,       % File handle
+                    hintfd :: port() | undefined,   % File handle for hints
                     hintcrc=0 :: integer(),  % CRC-32 of current hint
-                    ofs :: non_neg_integer(), % Current offset for writing
+                    ofs=0 :: non_neg_integer(), % Current offset for writing
                     l_ofs=0 :: non_neg_integer(),  % Last offset written to data file
                     l_hbytes=0 :: non_neg_integer(),% Last # bytes written to hint file
                     l_hintcrc=0 :: non_neg_integer()}). % CRC-32 of current hint prior to last write

--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,5 @@
 {erl_opts, [debug_info, warn_untyped_record,
+            {parse_transform, stacktrace_transform},
             {platform_define, "^[0-9]+", namespaced_types}]}.
 {port_specs, [{"priv/bitcask.so", ["c_src/*.c"]}]}.
 
@@ -19,6 +20,10 @@
   {"darwin10.*-32$", "CFLAGS", "-m32"},
   {"darwin10.*-32$", "LDFLAGS", "-arch i386"}
  ]}.
+
+{deps, [
+    {stacktrace_compat, "1.0.0"}
+]}.
 
 {profiles,
  [

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,1 +1,6 @@
-[].
+{"1.1.0",
+[{<<"stacktrace_compat">>,{pkg,<<"stacktrace_compat">>,<<"1.0.0">>},0}]}.
+[
+{pkg_hash,[
+ {<<"stacktrace_compat">>, <<"78E13E0747FABC71DC725A49A4CBDDE54CEC1E9ED13BD80C1D35AC37182E1FA0">>}]}
+].

--- a/src/bitcask.erl
+++ b/src/bitcask.erl
@@ -3074,6 +3074,7 @@ corrupt_file(Path, Offset, Data) ->
     ok = file:write(FH, Data),
     file:close(FH).
 
+-ifndef(OTP_RELEASE). %% only applies to OTP20 and earlier
 % Verify that if the cached efile port goes away, we can recover
 % and not get stuck opening casks
 efile_error_test() ->
@@ -3092,6 +3093,7 @@ efile_error_test() ->
         B2 when is_reference(B2) ->
             ok = bitcask:close(B2)
     end.
+-endif.
 
 %% About leak_t0():
 %%

--- a/src/bitcask_file.erl
+++ b/src/bitcask_file.erl
@@ -39,8 +39,8 @@
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
          terminate/2, code_change/3]).
 
--record(state, {fd    :: file:fd(),
-                owner :: pid()}).
+-record(state, {fd    :: file:fd() | undefined,
+                owner :: pid() | undefined}).
 
 %%%===================================================================
 %%% API

--- a/src/bitcask_fileops.erl
+++ b/src/bitcask_fileops.erl
@@ -783,14 +783,24 @@ hintfile_entry(Key, Tstamp, TombInt, Offset, TotalSz) ->
        TombInt:?TOMBSTONEFIELD_V2, Offset:?OFFSETFIELD_V2>>, Key].
 
 %% ===================================================================
-%% file/filelib avoidance code.
+%% file/filelib avoidance code. Only needed for pre OTP-21 releases.
 %% ===================================================================
 
+-ifdef(OTP_RELEASE).
+read_file_info(Filename) ->
+    file:read_file_info(Filename).
+
+write_file_info(FileName, Info) ->
+    file:write_file_info(FileName, Info).
+-else.
 read_file_info(FileName) ->
     prim_file:read_file_info(FileName).
 
 write_file_info(FileName, Info) ->
     prim_file:write_file_info(FileName, Info).
+
+-endif.
+
 
 is_file(File) ->
     case read_file_info(File) of
@@ -840,6 +850,11 @@ ensure_dir(F) ->
 list_dir(Dir) ->
     list_dir(Dir, 1).
 
+
+-ifdef(OTP_RELEASE).
+list_dir(Directory, Retries) when is_integer(Retries), Retries > 0 ->
+    file:list_dir(Directory).
+-else.
 list_dir(_, 0) ->
     {error, efile_driver_unavailable};
 list_dir(Directory, Retries) when is_integer(Retries), Retries > 0 ->
@@ -880,4 +895,4 @@ prim_file_drv_open(Driver, Portopts) ->
         error:Reason ->
             {error, Reason}
     end.
-
+-endif.


### PR DESCRIPTION
This branch makes bitcask *work* (although there might be a slight performance degredation) on OTP21 and it fixes all the dialyzer warnings.