### PR TITLE
Do not warn for export_all in test code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: compile rel cover test dialyzer
+.PHONY: compile rel cover test dialyzer eqc
 REBAR=./rebar3
 
 compile:
@@ -15,6 +15,9 @@ test: compile
 
 dialyzer:
 	$(REBAR) dialyzer
+
+eqc:
+	$(REBAR) eqc
 
 xref:
 	$(REBAR) xref

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ cover: test
 	$(REBAR) cover
 
 test: compile
-	$(REBAR) as test do eunit
+	$(REBAR) eunit
 
 dialyzer:
 	$(REBAR) dialyzer

--- a/eqc/bitcask_qc.erl
+++ b/eqc/bitcask_qc.erl
@@ -27,7 +27,7 @@
 -include_lib("eunit/include/eunit.hrl").
 -include("include/bitcask.hrl").
 
--compile(export_all).
+-compile([export_all, nowarn_export_all]).
 
 -define(QC_OUT(P),
         eqc:on_output(fun(Str, Args) -> io:format(user, Str, Args) end, P)).

--- a/eqc/bitcask_qc_expiry.erl
+++ b/eqc/bitcask_qc_expiry.erl
@@ -27,7 +27,7 @@
 -include_lib("eunit/include/eunit.hrl").
 -include("include/bitcask.hrl").
 
--compile(export_all).
+-compile([export_all, nowarn_export_all]).
 
 keys() ->
     eqc_gen:non_empty(list(eqc_gen:non_empty(binary()))).
@@ -176,4 +176,3 @@ validate_live([{K, {Value, _}} | Rest], Actual) ->
 
 
 -endif.
-

--- a/eqc/bitcask_qc_fsm.erl
+++ b/eqc/bitcask_qc_fsm.erl
@@ -33,7 +33,7 @@
 -include_lib("eqc/include/eqc_fsm.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
--compile(export_all).
+-compile([export_all, nowarn_export_all]).
 
 -record(state,{ bitcask :: reference(),
                 data = [] :: list(),

--- a/eqc/event_logger.erl
+++ b/eqc/event_logger.erl
@@ -1,10 +1,10 @@
 %%% File        : handle_errors.erl
 %%% Author      : Ulf Norell
-%%% Description : 
+%%% Description :
 %%% Created     : 26 Mar 2012 by Ulf Norell
 -module(event_logger).
 
--compile(export_all).
+-compile([export_all, nowarn_export_all]).
 
 -behaviour(gen_server).
 
@@ -128,6 +128,4 @@ add_event(#event{timestamp = Now, data = Data}, State) ->
   State#state{ events = [Event|State#state.events] }.
 
 timestamp() ->
-  {A, B, C} = erlang:now(),
-  1000000 * (1000000 * A + B) + C.
-
+    erlang:system_time(microsecond).

--- a/eqc/generic_qc_fsm.erl
+++ b/eqc/generic_qc_fsm.erl
@@ -61,7 +61,7 @@
 -include_lib("kernel/include/file.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
--compile(export_all).
+-compile([export_all, nowarn_export_all]).
 
 -record(state,{ handle :: term(),
                 dir :: term(),

--- a/src/bitcask.erl
+++ b/src/bitcask.erl
@@ -57,7 +57,7 @@
 -endif.
 
 -ifdef(TEST).
--compile(export_all).
+-compile([export_all, nowarn_export_all]).
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("kernel/include/file.hrl").
 -export([leak_t0/0, leak_t1/0]).

--- a/src/bitcask_fileops.erl
+++ b/src/bitcask_fileops.erl
@@ -55,11 +55,7 @@
 -endif.
 
 -ifdef(TEST).
--ifdef(EQC).
--include_lib("eqc/include/eqc.hrl").
--include_lib("eqc/include/eqc_fsm.hrl").
--endif.
--compile(export_all).
+-compile([export_all, nowarn_export_all]).
 -include_lib("eunit/include/eunit.hrl").
 -endif.
 
@@ -880,4 +876,3 @@ prim_file_drv_open(Driver, Portopts) ->
         error:Reason ->
             {error, Reason}
     end.
-

--- a/src/bitcask_merge_delete.erl
+++ b/src/bitcask_merge_delete.erl
@@ -39,7 +39,7 @@
 -include_lib("kernel/include/file.hrl").
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
--compile(export_all).
+-compile([export_all, nowarn_export_all]).
 -endif.
 
 -define(SERVER, ?MODULE).

--- a/src/bitcask_merge_worker.erl
+++ b/src/bitcask_merge_worker.erl
@@ -30,6 +30,7 @@
 -ifdef(TEST).
 -ifdef(EQC).
 -include_lib("eqc/include/eqc.hrl").
+-export([prop_in_window/0]).
 -endif.
 -include_lib("eunit/include/eunit.hrl").
 -endif.

--- a/src/bitcask_nifs.erl
+++ b/src/bitcask_nifs.erl
@@ -76,7 +76,7 @@
 -ifdef(EQC).
 -include_lib("eqc/include/eqc.hrl").
 -endif.
--compile(export_all).
+-compile([export_all, nowarn_export_all]).
 -include_lib("eunit/include/eunit.hrl").
 -endif.
 

--- a/test/bitcask_timeshift.erl
+++ b/test/bitcask_timeshift.erl
@@ -24,7 +24,7 @@
 -include_lib("eunit/include/eunit.hrl").
 -include("bitcask.hrl").
 
--compile(export_all).
+-compile([export_all, nowarn_export_all]).
 
 current_tstamp() ->
     case erlang:get(meck_tstamp) of

--- a/test/mute.erl
+++ b/test/mute.erl
@@ -4,7 +4,7 @@
 %%% Created     : 26 Mar 2012 by Ulf Norell
 -module(mute).
 
--compile(export_all).
+-compile([export_all, nowarn_export_all]).
 
 % Call Fun with output suppressed.
 run(Fun) ->

--- a/test/utils.erl
+++ b/test/utils.erl
@@ -5,7 +5,7 @@
 %%% Created     : 21 Mar 2012 by Ulf Norell
 -module(utils).
 
--compile(export_all).
+-compile([export_all, nowarn_export_all]).
 
 whereis(Name) ->
   erlang:whereis(Name).


### PR DESCRIPTION
Making QuickCheck tests compile without warnings 
(apart from warnings  in dependencies)