### PR TITLE
Fix `O_SYNC` flag when opening data files

### DIFF
--- a/src/bitcask_fileops.erl
+++ b/src/bitcask_fileops.erl
@@ -84,7 +84,7 @@ create_file(DirName, Opts0, Keydir) ->
                 FinalOpts =
                     case bitcask:get_opt(sync_strategy, Opts) of
                         o_sync ->
-                            [o_sync | Opts];
+                            Opts ++ [o_sync];
                         _ ->
                             Opts
                     end,


### PR DESCRIPTION
According to [Riak's docs](https://docs.riak.com/riak/kv/2.2.3/setup/planning/backend/bitcask/index.html#sync-strategy), using the POSIX C API to write files, together with the `o_sync` strategy, should result in synchronous data writes. However, when looking at the open file descriptors for the Bitcask data, we can see that only the `.write.lock` files are opened with the `O_SYNC` flag, e.g.:

```
COMMAND     PID   TID TASKCMD   USER   FD      TYPE         FILE-FLAG             DEVICE SIZE/OFF    NODE NAME
beam.smp  86800 87045 Eleveldb  root  489u      REG         RW,SYN,LG              0,183       86 2043031 /riak/rel/riak/data/bitcask/1324485858831130769622089379649131486563188867072/bitcask.write.lock
beam.smp  86800 87045 Eleveldb  root  490u      REG          RW,AP,LG              0,183    14767 2043032 /riak/rel/riak/data/bitcask/319703483166135013357056057156686910549735243776/1.bitcask.data
beam.smp  86800 87045 Eleveldb  root  491u      REG          RW,AP,LG              0,183     3036 2043033 /riak/rel/riak/data/bitcask/319703483166135013357056057156686910549735243776/1.bitcask.hint
beam.smp  86800 87045 Eleveldb  root  493u      REG          RW,AP,LG              0,183    13427 2043035 /riak/rel/riak/data/bitcask/1324485858831130769622089379649131486563188867072/1.bitcask.data
beam.smp  86800 87045 Eleveldb  root  494u      REG          RW,AP,LG              0,183     2760 2043036 /riak/rel/riak/data/bitcask/1324485858831130769622089379649131486563188867072/1.bitcask.hint
...
```

This means writes are still asynchronous, which could lead to data loss even after sending the reply to the client.

The reason for this is that while the `get_file_open_flags` C function adds the `O_SYNC` to the bitmask, it replaces it when it receives an `ATOM_CREATE` option. The easiest fix is to simply add the `o_sync` option to the end of the list at `bitcask_fileops.erl:87`, to ensure that it always appears after the `create`. Now the files are correctly opened with the `O_SYNC` flag:

```
COMMAND     PID   TID TASKCMD   USER   FD      TYPE         FILE-FLAG             DEVICE SIZE/OFF    NODE NAME
beam.smp   4080 6414 Eleveldb  root  553u      REG         RW,SYN,LG              0,183       85 2043159 /riak/rel/riak/data/bitcask/1324485858831130769622089379649131486563188867072/bitcask.write.lock
beam.smp   4080 6414 Eleveldb  root  554u      REG      RW,AP,SYN,LG              0,183     5106 2043160 /riak/rel/riak/data/bitcask/319703483166135013357056057156686910549735243776/1.bitcask.data
beam.smp   4080 6414 Eleveldb  root  555u      REG      RW,AP,SYN,LG              0,183     1058 2043161 /riak/rel/riak/data/bitcask/319703483166135013357056057156686910549735243776/1.bitcask.hint
beam.smp   4080 6414 Eleveldb  root  557u      REG      RW,AP,SYN,LG              0,183     3988 2043163 /riak/rel/riak/data/bitcask/1324485858831130769622089379649131486563188867072/1.bitcask.data
beam.smp   4080 6414 Eleveldb  root  558u      REG      RW,AP,SYN,LG              0,183      828 2043164 /riak/rel/riak/data/bitcask/1324485858831130769622089379649131486563188867072/1.bitcask.hint
...
```
